### PR TITLE
Allow any test env name using env variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "tsc && vite build",
         "serve": "vite preview",
         "predeploy": "npm run build -- --config vite.config.test-env.ts",
-        "deploy": "gh-pages --dist dist --dest test-env",
+        "deploy": "gh-pages --dist dist --dest ${TEST_ENV_NAME:-test-env}",
         "test": "vitest",
         "test:coverage": "vitest run --coverage --watch=false",
         "storybook": "storybook dev -p 6006",

--- a/vite.config.test-env.ts
+++ b/vite.config.test-env.ts
@@ -1,6 +1,14 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import viteConfig from './vite.config'
 
+const getTestEnvName = () => {
+    if(process.env.TEST_ENV_NAME != null){
+        return process.env.TEST_ENV_NAME
+    } else {
+        return "test-env"
+    }
+}
+
 export default mergeConfig(viteConfig, defineConfig({
-    base: "/pokelingo/test-env",
+    base: `/pokelingo/${getTestEnvName()}`,
 }))


### PR DESCRIPTION
### How to use
Run the below to use a custom test environment name
```
TEST_ENV_NAME=$MY_TEST_ENV_NAME npm run deploy
```

### Example
```
TEST_ENV_NAME=kodaku npm run deploy
```
Will deploy to the `kodaku` test env available at https://kimanhou.github.io/pokelingo/kodaku/

### Default
Will default to  `test-env` test environment available at https://kimanhou.github.io/pokelingo/test-env/