### PR TITLE
👷 Refactor environment deployment path to be under env/

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "tsc && vite build",
         "serve": "vite preview",
         "predeploy": "npm run build -- --config vite.config.test-env.ts",
-        "deploy": "gh-pages --dist dist --dest ${TEST_ENV_NAME:-test-env}",
+        "deploy": "gh-pages --dist dist --dest env/${TEST_ENV_NAME:-test}",
         "test": "vitest",
         "test:coverage": "vitest run --coverage --watch=false",
         "storybook": "storybook dev -p 6006",

--- a/vite.config.test-env.ts
+++ b/vite.config.test-env.ts
@@ -5,10 +5,10 @@ const getTestEnvName = () => {
     if(process.env.TEST_ENV_NAME != null){
         return process.env.TEST_ENV_NAME
     } else {
-        return "test-env"
+        return "test"
     }
 }
 
 export default mergeConfig(viteConfig, defineConfig({
-    base: `/pokelingo/${getTestEnvName()}`,
+    base: `/pokelingo/env/${getTestEnvName()}`,
 }))


### PR DESCRIPTION
Refactoring work for better segregation of test environments

Non-prod test environments will now be deployed under `/env`, gathering all test environments under one folder


Default test environment is now https://kimanhou.github.io/pokelingo/env/test/